### PR TITLE
Update API URL, add more parameters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   owner:
     description: "The owner of the repository where the workflow is contained."
     required: true
+  ref:
+    description: 'The reference of the workflow run. The reference can be a branch, tag, or a commit SHA'
+    required: true
   repo:
     description: "The repository where the workflow is contained."
     required: true
@@ -23,8 +26,8 @@ inputs:
   workflow_file_name:
     description: "The reference point. For example, you could use main.yml."
     required: true
-  client_payload:
-    description: "JSON payload with extra information about the webhook event that your action or worklow may use. Default: {}"
+  inputs:
+    description: 'Inputs to pass to the workflow, must be a JSON string'
     required: false
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   inputs:
     description: 'Inputs to pass to the workflow, must be a JSON string'
     required: false
+  propagate_failure:
+    description: 'Fail current job if downstream job fails. default: true'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   propagate_failure:
     description: 'Fail current job if downstream job fails. default: true'
     required: false
+  wait_only:
+    description: 'Wait without triggering the workflow. default: false'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,11 @@ inputs:
   propagate_failure:
     description: 'Fail current job if downstream job fails. default: true'
     required: false
-  wait_only:
-    description: 'Wait without triggering the workflow. default: false'
+  trigger_workflow:
+    description: 'Trigger the specified workflow. default: true'
+    required: false
+  wait_workflow:
+    description: 'Wait for workflow to finish. default: true'
     required: false
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,6 +52,12 @@ function validate_args {
     exit 1
   fi
 
+  inputs=$(echo '{}' | jq)
+  if [ "$INPUT_INPUTS" ]
+  then
+    inputs=$(echo $INPUT_INPUTS | jq)
+  fi
+
   # client_payload=$(echo '{}' | jq)
   # if [ "$INPUT_CLIENT_PAYLOAD" ]
   # then
@@ -61,11 +67,12 @@ function validate_args {
 
 function trigger_workflow {
   echo "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/$INPUT_WORKFLOW_FILE_NAME/dispatches"
+
   curl -X POST "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/$INPUT_WORKFLOW_FILE_NAME/dispatches" \
-    -H "Accept: application/vnd.github.everest-preview+json" \
+    -H "Accept: application/vnd.github.v3+json" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
-    --data "{\"ref\": \"${INPUT_REF}\", \"inputs\": ${INPUT_INPUTS} }"
+    --data "{\"ref\":\"${INPUT_REF}\",\"inputs\":${inputs}}"
   sleep $wait_interval
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,12 +57,6 @@ function validate_args {
   then
     inputs=$(echo $INPUT_INPUTS | jq)
   fi
-
-  # client_payload=$(echo '{}' | jq)
-  # if [ "$INPUT_CLIENT_PAYLOAD" ]
-  # then
-  #   client_payload=$(echo $INPUT_CLIENT_PAYLOAD | jq)
-  # fi
 }
 
 function trigger_workflow {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,10 +22,16 @@ function validate_args {
     propagate_failure=$INPUT_PROPAGATE_FAILURE
   fi
 
-  wait_only=false
-  if [ -n "$INPUT_WAIT_ONLY" ]
+  trigger_workflow=true
+  if [ -n "$INPUT_TRIGGER_WORKFLOW" ]
   then
-    wait_only=$INPUT_WAIT_ONLY
+    trigger_workflow=$INPUT_TRIGGER_WORKFLOW
+  fi
+
+  wait_workflow=true
+  if [ -n "$INPUT_WAIT_WORKFLOW" ]
+  then
+    wait_workflow=$INPUT_WAIT_WORKFLOW
   fi
 
   if [ -z "$INPUT_OWNER" ]
@@ -122,14 +128,19 @@ function wait_for_workflow_to_finish {
 function main {
   validate_args
 
-  if [ "$wait_only" = false ]
+  if [ "$trigger_workflow" = true ]
   then
     trigger_workflow
   else
-    echo "wait_only = true, skipping triggering the workflow."
+    echo "Skipping triggering the workflow."
   fi
 
-  wait_for_workflow_to_finish
+  if [ "$wait_workflow" = true ]
+  then
+    wait_for_workflow_to_finish
+  else
+    echo "Skipping waiting for workflow."
+  fi
 }
 
 main

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,12 @@ function validate_args {
     propagate_failure=$INPUT_PROPAGATE_FAILURE
   fi
 
+  wait_only=false
+  if [ -n "$INPUT_WAIT_ONLY" ]
+  then
+    wait_only=$INPUT_WAIT_ONLY
+  fi
+
   if [ -z "$INPUT_OWNER" ]
   then
     echo "Error: Owner is a required arugment."
@@ -115,7 +121,14 @@ function wait_for_workflow_to_finish {
 
 function main {
   validate_args
-  trigger_workflow
+
+  if [ "$wait_only" = false ]
+  then
+    trigger_workflow
+  else
+    echo "wait_only = true, skipping triggering the workflow."
+  fi
+
   wait_for_workflow_to_finish
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,12 @@ function validate_args {
     wait_interval=$INPUT_WAITING_INTERVAL
   fi
 
+  propagate_failure=true
+  if [ -n "$INPUT_PROPAGATE_FAILURE" ]
+  then
+    propagate_failure=$INPUT_PROPAGATE_FAILURE
+  fi
+
   if [ -z "$INPUT_OWNER" ]
   then
     echo "Error: Owner is a required arugment."
@@ -99,7 +105,11 @@ function wait_for_workflow_to_finish {
   else
     # Alternative "failure"
     echo "Conclusion is not success, its [$conclusion]."
-    exit 1
+    if [ "$propagate_failure" = true ]
+    then
+      echo "Propagating failure to upstream job"
+      exit 1
+    fi
   fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,20 +52,20 @@ function validate_args {
     exit 1
   fi
 
-  client_payload=$(echo '{}' | jq)
-  if [ "$INPUT_CLIENT_PAYLOAD" ]
-  then
-    client_payload=$(echo $INPUT_CLIENT_PAYLOAD | jq)
-  fi
+  # client_payload=$(echo '{}' | jq)
+  # if [ "$INPUT_CLIENT_PAYLOAD" ]
+  # then
+  #   client_payload=$(echo $INPUT_CLIENT_PAYLOAD | jq)
+  # fi
 }
 
 function trigger_workflow {
-  echo "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/dispatches"
-  curl -X POST "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/dispatches" \
+  echo "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/$INPUT_WORKFLOW_FILE_NAME/dispatches"
+  curl -X POST "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/$INPUT_WORKFLOW_FILE_NAME/dispatches" \
     -H "Accept: application/vnd.github.everest-preview+json" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
-    --data "{\"event_type\": \"${event_type}\", \"client_payload\": $client_payload }"
+    --data "{\"ref\": \"${INPUT_REF}\", \"inputs\": ${INPUT_INPUTS} }"
   sleep $wait_interval
 }
 


### PR DESCRIPTION
According to [documentation](https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-a-workflow-dispatch-event) the API for triggering workflow dispatch event is `/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches`, I guess this action was using an outdated version, thus I couldn't create an event out of the box.

Also I added some additional parameters that were useful to me and I guess it could be for others:
- ref
- inputs: pass arguments to the action that is being triggered (renamed from `client_payload`, this is according to the latest docs)
- propagate_failure: whether to fail the parent job if the child fails
- trigger_workflow: maybe you just want to wait for a job to finish
- wait_workflow: maybe you just want to trigger the job
