### PR TITLE
feat: Reducing time taken when wait_workflow used

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When deploying an app you may need to deploy additional services, this Github Ac
 
 ### Simple
 
-```
+```yaml
 - uses: convictional/trigger-workflow-and-wait@v1.3.0
   with:
     owner: keithconvictional
@@ -37,7 +37,7 @@ When deploying an app you may need to deploy additional services, this Github Ac
 
 ### All Options
 
-```
+```yaml
 - uses: convictional/trigger-workflow-and-wait@v1.3.0
   with:
     owner: keithconvictional
@@ -57,7 +57,7 @@ When deploying an app you may need to deploy additional services, this Github Ac
 
 You can test out the action locally by cloning the repository to your computer. You can run:
 
-```
+```shell
 INPUT_WAITING_INTERVAL=10 \
   INPUT_PROPAGATE_FAILURE=false \
   INPUT_TRIGGER_WORKFLOW=true \
@@ -72,7 +72,7 @@ INPUT_WAITING_INTERVAL=10 \
 
 You will have to create a Github Personal access token. You can create a test workflow to be executed. In a repository, add a new `main.yml` to `.github/workflows/`. The workflow will be:
 
-```
+```shell
 name: Main
 on:
   workflow_dispatch
@@ -88,7 +88,7 @@ jobs:
 
 You can see the example [here](https://github.com/keithconvictional/trigger-workflow-and-wait-example-repo1/blob/master/.github/workflows/main.yml). For testing a failure case, just add this line after the sleep:
 
-```
+```yaml
 ...
 - name: Pause for 25 seconds
   run: |
@@ -97,19 +97,17 @@ You can see the example [here](https://github.com/keithconvictional/trigger-work
     exit 1
 ```
 
-
 ## Potential Issues
 
 ### Timing
 
 The actions dispatch is an asynchronous job and it at times can take a few seconds to start. If you do not have a delay, it may be started after the action has checked if it was successful. ie. Start dispatch call --> No delay --> Check if successful --> Actually starts. If the workflow has run before, it will just complete immediately as a successful run. You can solve this by simply increasing the delay to a few seconds. By default it is 10 seconds. Creating a large delay between checks will help the traffic to the Github API.
 
-
 ### Changes
 
 If you do not want the latest build all of the time, please use a versioned copy of the Github Action. You specify the version after the `@` sign.
 
-```
+```yaml
 - uses: convictional/trigger-workflow-and-wait@v1.3.0
   with:
     owner: keithconvictional

--- a/contribute.md
+++ b/contribute.md
@@ -1,6 +1,5 @@
 # Contribute
 
-
-```
+```shell
 docker build . -t trigger-workflow-and-wait
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,6 @@
-function usage_docs {
+#!/bin/sh
+
+usage_docs() {
   echo ""
   echo "You can use this Github Action with:"
   echo "- uses: convictional/trigger-workflow-and-wait"
@@ -9,46 +11,46 @@ function usage_docs {
   echo "    workflow_file_name: main.yaml"
 }
 
-function validate_args {
+validate_args() {
   wait_interval=10 # Waits for 10 seconds
-  if [ "$INPUT_WAITING_INTERVAL" ]
+  if [ "${INPUT_WAITING_INTERVAL}" ]
   then
-    wait_interval=$INPUT_WAITING_INTERVAL
+    wait_interval=${INPUT_WAITING_INTERVAL}
   fi
 
   propagate_failure=true
-  if [ -n "$INPUT_PROPAGATE_FAILURE" ]
+  if [ -n "${INPUT_PROPAGATE_FAILURE}" ]
   then
-    propagate_failure=$INPUT_PROPAGATE_FAILURE
+    propagate_failure=${INPUT_PROPAGATE_FAILURE}
   fi
 
   trigger_workflow=true
-  if [ -n "$INPUT_TRIGGER_WORKFLOW" ]
+  if [ -n "${INPUT_TRIGGER_WORKFLOW}" ]
   then
-    trigger_workflow=$INPUT_TRIGGER_WORKFLOW
+    trigger_workflow=${INPUT_TRIGGER_WORKFLOW}
   fi
 
   wait_workflow=true
-  if [ -n "$INPUT_WAIT_WORKFLOW" ]
+  if [ -n "${INPUT_WAIT_WORKFLOW}" ]
   then
-    wait_workflow=$INPUT_WAIT_WORKFLOW
+    wait_workflow=${INPUT_WAIT_WORKFLOW}
   fi
 
-  if [ -z "$INPUT_OWNER" ]
+  if [ -z "${INPUT_OWNER}" ]
   then
     echo "Error: Owner is a required argument."
     usage_docs
     exit 1
   fi
 
-  if [ -z "$INPUT_REPO" ]
+  if [ -z "${INPUT_REPO}" ]
   then
     echo "Error: Repo is a required argument."
     usage_docs
     exit 1
   fi
 
-  if [ -z "$INPUT_GITHUB_TOKEN" ]
+  if [ -z "${INPUT_GITHUB_TOKEN}" ]
   then
     echo "Error: Github token is required. You can head over settings and"
     echo "under developer, you can create a personal access tokens. The"
@@ -57,7 +59,7 @@ function validate_args {
     exit 1
   fi
 
-  if [ -z $INPUT_WORKFLOW_FILE_NAME ]
+  if [ -z "${INPUT_WORKFLOW_FILE_NAME}" ]
   then
     echo "Error: Workflow File Name is required"
     usage_docs
@@ -65,61 +67,59 @@ function validate_args {
   fi
 
   inputs=$(echo '{}' | jq)
-  if [ "$INPUT_INPUTS" ]
+  if [ "${INPUT_INPUTS}" ]
   then
-    inputs=$(echo $INPUT_INPUTS | jq)
+    inputs=$(echo "${INPUT_INPUTS}" | jq)
   fi
 
   ref="main"
   if [ "$INPUT_REF" ]
   then
-    ref=$INPUT_REF
+    ref="${INPUT_REF}"
   fi
 }
 
-function trigger_workflow {
-  echo "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/$INPUT_WORKFLOW_FILE_NAME/dispatches"
+trigger_workflow() {
+  echo "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches"
 
-  curl -X POST "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/$INPUT_WORKFLOW_FILE_NAME/dispatches" \
+  curl -X POST "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches" \
     -H "Accept: application/vnd.github.v3+json" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
     --data "{\"ref\":\"${ref}\",\"inputs\":${inputs}}"
-  echo "Sleeping for $wait_interval seconds"
-  sleep $wait_interval
 }
 
-function wait_for_workflow_to_finish {
+wait_for_workflow_to_finish() {
   # Find the id of the last build
-  last_workflow=$(curl -X GET "https://api.github.com/repos/$INPUT_OWNER/$INPUT_REPO/actions/workflows/$INPUT_WORKFLOW_FILE_NAME/runs" \
+  last_workflow=$(curl -X GET "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_FILE_NAME}/runs" \
     -H 'Accept: application/vnd.github.antiope-preview+json' \
-    -H "Authorization: Bearer $INPUT_GITHUB_TOKEN" | jq '[.workflow_runs[]] | first')
-  last_workflow_id=$(echo $last_workflow | jq '.id')
-  echo "The workflow id is [$last_workflow_id]."
+    -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" | jq '[.workflow_runs[]] | first')
+  last_workflow_id=$(echo "${last_workflow}" | jq '.id')
+  echo "The workflow id is [${last_workflow_id}]."
   echo ""
-  conclusion=$(echo $last_workflow | jq '.conclusion')
-  status=$(echo $last_workflow | jq '.status')
+  conclusion=$(echo "${last_workflow}" | jq '.conclusion')
+  status=$(echo "${last_workflow}" | jq '.status')
 
-  while [[ $conclusion == "null" && $status != "\"completed\"" ]]
+  while [[ "${conclusion}" == "null" && "${status}" != "\"completed\"" ]]
   do
-    echo "Sleeping for $wait_interval seconds"
-    sleep $wait_interval
-    workflow=$(curl -X GET "https://api.github.com/repos/$INPUT_OWNER/$INPUT_REPO/actions/workflows/$INPUT_WORKFLOW_FILE_NAME/runs" \
+    echo "Sleeping for \"${wait_interval}\" seconds"
+    sleep "${wait_interval}"
+    workflow=$(curl -X GET "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_FILE_NAME}/runs" \
       -H 'Accept: application/vnd.github.antiope-preview+json' \
-      -H "Authorization: Bearer $INPUT_GITHUB_TOKEN" | jq '.workflow_runs[] | select(.id == '$last_workflow_id')')
-    conclusion=$(echo $workflow | jq '.conclusion')
-    status=$(echo $workflow | jq '.status')
-    echo "Checking conclusion [$conclusion]"
-    echo "Checking status [$status]"
+      -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" | jq '.workflow_runs[] | select(.id == '${last_workflow_id}')')
+    conclusion=$(echo "${workflow}" | jq '.conclusion')
+    status=$(echo "${workflow}" | jq '.status')
+    echo "Checking conclusion [${conclusion}]"
+    echo "Checking status [${status}]"
   done
 
-  if [[ $conclusion == "\"success\"" && $status == "\"completed\"" ]]
+  if [[ "${conclusion}" == "\"success\"" && "${status}" == "\"completed\"" ]]
   then
     echo "Yes, success"
   else
     # Alternative "failure"
-    echo "Conclusion is not success, its [$conclusion]."
-    if [ "$propagate_failure" = true ]
+    echo "Conclusion is not success, its [${conclusion}]."
+    if [ "${propagate_failure}" = true ]
     then
       echo "Propagating failure to upstream job"
       exit 1
@@ -127,17 +127,17 @@ function wait_for_workflow_to_finish {
   fi
 }
 
-function main {
+main() {
   validate_args
 
-  if [ "$trigger_workflow" = true ]
+  if [ "${trigger_workflow}" = true ]
   then
     trigger_workflow
   else
     echo "Skipping triggering the workflow."
   fi
 
-  if [ "$wait_workflow" = true ]
+  if [ "${wait_workflow}" = true ]
   then
     wait_for_workflow_to_finish
   else


### PR DESCRIPTION
* [modified] Avoidable loss of 10sec of runner

The sleep in `trigger_workflow` is a loss of 10 seconds on Github runners (which [cost money](https://docs.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions)) that can be avoided since `wait_for_workflow_to_finish` will still do the job if user wants to wait for workflow.
**Especially if a user uses `wait_workflow=false` since he specifically asks to not wait.**

Concerned lines:
```shell
echo "Sleeping for $wait_interval seconds"
sleep $wait_interval
```

* [modified] Ash script issues
  * https://github.com/koalaman/shellcheck/wiki/SC2113
  * https://github.com/koalaman/shellcheck/wiki/SC2086
  * https://fr.wikipedia.org/wiki/Shebang
  * https://dev.to/meleu/what-the-shebang-really-does-and-why-it-s-so-important-in-your-shell-scripts-2755
 
* [modified] README.md - applying markdown best practices