### PR TITLE
Add logic to fetch the triggered workflow id

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ When deploying an app you may need to deploy additional services, this Github Ac
 | `owner`               | True       | N/A         | The owner of the repository where the workflow is contained. |
 | `repo`                | True       | N/A         | The repository where the workflow is contained. |
 | `github_token`        | True       | N/A         | The Github access token with access to the repository. Its recommended you put it under secrets. |
-| `workflow_file_name`  | True      | N/A      | The reference point. For example, you could use main.yml. |
-| `ref`       | False      | main          | The reference of the workflow run. The reference can be a branch, tag, or a commit SHA. |
-| `waiting_interval`       | False      | 10          | The number of seconds delay between checking for result of run. |
-| `inputs`  | False       | `{}`         | Inputs to pass to the workflow, must be a JSON string |
-| `propagate_failure`      | False      | `true`        | Fail current job if downstream job fails. |
-| `trigger_workflow`       | False      | `true`        | Trigger the specified workflow. |
-| `wait_workflow`          | False      | `true`        | Wait for workflow to finish. |
+| `workflow_file_name`  | True       | N/A         | The reference point. For example, you could use main.yml. |
+| `github_user`         | False      | N/A         | The name of the github user whose access token is being used to trigger the workflow. |
+| `ref`                 | False      | main        | The reference of the workflow run. The reference can be a branch, tag, or a commit SHA. |
+| `waiting_interval`    | False      | 10          | The number of seconds delay between checking for result of run. |
+| `inputs`              | False      | `{}`        | Inputs to pass to the workflow, must be a JSON string |
+| `propagate_failure`   | False      | `true`      | Fail current job if downstream job fails. |
+| `trigger_workflow`    | False      | `true`      | Trigger the specified workflow. |
+| `wait_workflow`       | False      | `true`      | Wait for workflow to finish. |
 
 
 ## Example
@@ -43,6 +44,7 @@ When deploying an app you may need to deploy additional services, this Github Ac
     owner: keithconvictional
     repo: myrepo
     github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+    github_user: github-user
     workflow_file_name: main.yml
     ref: release-branch
     wait_interval: 10
@@ -62,6 +64,7 @@ INPUT_WAITING_INTERVAL=10 \
   INPUT_PROPAGATE_FAILURE=false \
   INPUT_TRIGGER_WORKFLOW=true \
   INPUT_WORKFLOW_FILE_NAME="main.yml" \
+  INPUT_GITHUB_USER="github-user" \
   INPUT_WAIT_WORKFLOW=true \
   INPUT_OWNER="keithconvictional" \
   INPUT_REPO="trigger-workflow-and-wait-example-repo1" \

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   github_token:
     description: "The Github access token with access to the repository. Its recommended you put it under secrets."
     required: true
+  github_user:
+    description: "The name of the github user whose access token is being used to trigger the workflow."
+    required: false
   ref:
     description: 'The reference of the workflow run. The reference can be a branch, tag, or a commit SHA. Default: main'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,10 +90,22 @@ trigger_workflow() {
 }
 
 wait_for_workflow_to_finish() {
-  # Find the id of the last build
-  last_workflow=$(curl -X GET "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_FILE_NAME}/runs" \
-    -H 'Accept: application/vnd.github.antiope-preview+json' \
-    -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" | jq '[.workflow_runs[]] | first')
+  # Find the id of the last run using filters to identify the workflow triggered by this action
+  echo "Getting the ID of the workflow..."
+  query="event=workflow_dispatch&status=queued"
+  if [ "$INPUT_GITHUB_USER" ]
+  then
+    query="${query}&actor=${INPUT_GITHUB_USER}"
+  fi
+  last_workflow="null"
+  while [[ "$last_workflow" == "null" ]]
+  do
+    echo "Using the following params to filter the workflow runs to get the triggered run id -"
+    echo "Query params: ${query}"
+    last_workflow=$(curl -X GET "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_FILE_NAME}/runs?${query}" \
+      -H 'Accept: application/vnd.github.antiope-preview+json' \
+      -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" | jq '[.workflow_runs[]] | first')
+  done
   last_workflow_id=$(echo "${last_workflow}" | jq '.id')
   last_workflow_url="https://github.com/${INPUT_OWNER}/${INPUT_REPO}/actions/runs/${last_workflow_id}"
   echo "The workflow id is [${last_workflow_id}]."


### PR DESCRIPTION
Currently, the logic used to fetch the last run of the workflow is not very reliable as sometimes the triggered workflow could take a while to be queued and in the meantime the action might pick up a previously executed workflow and report wrong conclusion.

To increase the reliability of the action, this PR adds certain query parameters while getting the last workflow run. Even though this still doesn't guarantee that the fetched workflow is in fact the one triggered by the action, the probability increases significantly.

The query parameters being used are -
- `status: queued`
- `event: workflow_dispatch`
- `actor: <github-username>` (Optional, provided by the user as input)
