### PR TITLE
Fail the task if there are errors

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 usage_docs() {
   echo ""
@@ -82,7 +83,7 @@ validate_args() {
 trigger_workflow() {
   echo "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches"
 
-  curl -X POST "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches" \
+  curl --fail -X POST "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches" \
     -H "Accept: application/vnd.github.v3+json" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \


### PR DESCRIPTION
At the moment the workflow won't fail even if there are errors in the initial dispatch. For example, if there is an error in the `ref` parameter, the output will look like this:

```
https://api.github.com/repos/scrive/new_frontend/actions/workflows/end2end-tests-workflow.yaml/dispatches
{
  "message": "No ref found for: main",
  "documentation_url": "https://docs.github.com/rest/reference/actions#create-a-workflow-dispatch-event"
}
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  346k  100  346k    0     0   380k      0 --:--:-- --:--:-- --:--:--  380k
The workflow id is [1358324068].
The workflow logs can be found at https://github.com/***/******/actions/runs/1358324068
::set-output name=workflow_id::1358324068
::set-output name=workflow_url::https://github.com/***/******/actions/runs/1358324068

Sleeping for "10" seconds
```

Same happens when the `inputs` parameter is not valid. I think the workflow should fail immediately in those cases.