### PR TITLE
action: add option to post the workflow URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ When deploying an app you may need to deploy additional services, this Github Ac
 | `propagate_failure`      | False      | `true`      | Fail current job if downstream job fails. |
 | `trigger_workflow`       | False      | `true`      | Trigger the specified workflow. |
 | `wait_workflow`          | False      | `true`      | Wait for workflow to finish. |
+| `comment_downstream_url` | False      | ''          | A comments API URL to comment the current downstream job URL to. Default: no comment |
 
 
 ## Example
@@ -54,6 +55,16 @@ When deploying an app you may need to deploy additional services, this Github Ac
     wait_workflow: true
 ```
 
+### Comment the current running workflow URL for a PR
+
+```yaml
+- uses: convictional/trigger-workflow-and-wait@v1.6.1
+  with:
+    owner: keithconvictional
+    repo: myrepo
+    github_token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+    comment_downstream_url: ${{ github.event.pull_request.comments_url }}
+```
 
 ## Testing
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
   wait_workflow:
     description: 'Wait for workflow to finish. default: true'
     required: false
+  comment_downstream_url:
+    description: 'Comment API link for commenting the downstream job URL'
+    required: false
+    default: ''
 outputs:
   workflow_id:
     description: The ID of the workflow that was triggered by this action


### PR DESCRIPTION
as a comment to a configurable comments API URL.
For instance when having very long running workflows called by the
action, it's hard for the user to see the actual pipeline and its
results.
For better tracebility and user expierence post the link to
the acquired workflow URL as a comment.

Typical setting would be to set it to
${{ github.event.pull_request.comments_url }} for pull requests.

As this may not be wanted by all users set the default to empty,
meaning no comments will be made