### PR TITLE
Expose Conclusion as an action output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ outputs:
   workflow_url:
     description: The URL of the workflow that was triggered by this action
   conclusion:
-    descrption: Conclusion of the job, i.e pass/failure
+    description: Conclusion of the job, i.e pass/failure
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,8 @@ outputs:
     description: The ID of the workflow that was triggered by this action
   workflow_url:
     description: The URL of the workflow that was triggered by this action
+  conclusion:
+    descrption: Conclusion of the job, i.e pass/failure
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -172,6 +172,7 @@ wait_for_workflow_to_finish() {
 
     echo "Checking conclusion [${conclusion}]"
     echo "Checking status [${status}]"
+    echo "::set-output name=conclusion::${conclusion}"
   done
 
   if [[ "${conclusion}" == "success" && "${status}" == "completed" ]]


### PR DESCRIPTION
Expose conclusion as an output of the action so that it can be referenced in later steps.
e.g ${{ steps.STEPID.outputs.conclusion }}

Use case: 
1. Run Job A (E.g setup)
2. Run Job B - Propagate failure
3. Run Job C (E.g tidy up)
4. Check conclusion of job B to determine if build should pass/fail