### PR TITLE
Use generated github token form pull_request comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ When deploying an app you may need to deploy additional services, this Github Ac
 | `trigger_workflow`       | False      | `true`      | Trigger the specified workflow. |
 | `wait_workflow`          | False      | `true`      | Wait for workflow to finish. |
 | `comment_downstream_url` | False      | ''          | A comments API URL to comment the current downstream job URL to. Default: no comment |
+| `comment_github_token` | False      | '${{github.token}}          | token used for pull_request comments |
 
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: 'Comment API link for commenting the downstream job URL'
     required: false
     default: ''
+  comment_github_token:
+    description: "The Github access token with access to the repository for comment URL. It is recommended you put this token under secrets."
+    required: false
+    default: ${{ github.token }}
 outputs:
   workflow_id:
     description: The ID of the workflow that was triggered by this action

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -155,7 +155,7 @@ trigger_workflow() {
 comment_downstream_link() {
   if response=$(curl --fail-with-body -sSL -X POST \
       "${INPUT_COMMENT_DOWNSTREAM_URL}" \
-      -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
+      -H "Authorization: Bearer ${INPUT_COMMENT_GITHUB_TOKEN}" \
       -H 'Accept: application/vnd.github.v3+json' \
       -d "{\"body\": \"Running downstream job at $1\"}")
   then


### PR DESCRIPTION
Hi,

There is two Github API call in this action: 

- one for trigger remote workflow with a specific PAT token
- one for pull_request comments.

By design, Github token has access to pull_request comment
I thin it's better to use autogenerated github token for pull request comments. Moreover, we didn't need comments pull request on remote repository.

What do you think about it ?

[Here](https://github.com/bogaertg/trigger-workflow-and-wait-test/pulls) is test repo for my fork 

Regards
Gaetan
