### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -193,14 +193,15 @@ wait_for_workflow_to_finish() {
 
     echo "Checking conclusion [${conclusion}]"
     echo "Checking status [${status}]"
-    echo "conclusion=${conclusion}" >> $GITHUB_OUTPUT
   done
 
   if [[ "${conclusion}" == "success" && "${status}" == "completed" ]]
   then
+    echo "conclusion=${conclusion}" >> $GITHUB_OUTPUT
     echo "Yes, success"
   else
     # Alternative "failure"
+    echo "conclusion=${conclusion}" >> $GITHUB_OUTPUT
     echo "Conclusion is not success, it's [${conclusion}]."
 
     if [ "${propagate_failure}" = true ]


### PR DESCRIPTION
Deleted the line #196 ----> echo "conclusion=${conclusion}" >> $GITHUB_OUTPUT Inserted new line #200 ----> echo "conclusion=${conclusion}" >> $GITHUB_OUTPUT Inserted new line #204 ----> echo "conclusion=${conclusion}" >> $GITHUB_OUTPUT

With this simple update, the routine is able to write the $conclusion value on the $GITHUB_OUTPUT, and now is possible to setup the "propagate_failure: false", and look at the result of the remote workflow action. You can try the functionality with my version below :) ....
    steps:
      - name: 'Run test' id: 'run-test' uses: Enrico-Infrinity/trigger-workflow-and-wait@v1.0 with: owner: remoteOwner repo: remoteRepo github_token: ${{ secrets.CICD_REPO_TOKEN }} workflow_file_name: main.yml ref: main wait_interval: 10 client_payload: '{}' propagate_failure: false trigger_workflow: true wait_workflow: true

      - name: 'Set result'
        run: |
          echo ${{ steps.run-test.outputs.conclusion }}
....


It's a simple workaround, but it's working well.

Enjoy!! :)