### PR TITLE
feat: print workflow URL to job summary

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,3 +51,4 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
           propagate_failure: true
+          summarize: true

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ When deploying an app you may need to deploy additional services, this Github Ac
 | `wait_workflow`          | False      | `true`      | Wait for workflow to finish. |
 | `comment_downstream_url` | False      | ``          | A comments API URL to comment the current downstream job URL to. Default: no comment |
 | `comment_github_token`   | False      | `${{github.token}}`          | token used for pull_request comments |
+| `summarize`              | False      | `false`     | Print downstream job URL and ID to workflow job summary |
 
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ inputs:
     description: "The Github access token with access to the repository for comment URL. It is recommended you put this token under secrets."
     required: false
     default: ${{ github.token }}
+  summarize:
+    description: "Print downstream job URL and ID to workflow job summary. default: false"
+    required: false
 outputs:
   workflow_id:
     description: The ID of the workflow that was triggered by this action

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,12 @@ validate_args() {
     wait_workflow=${INPUT_WAIT_WORKFLOW}
   fi
 
+  summarize=false
+  if [ -n "${INPUT_SUMMARIZE}" ]
+  then
+    summarize=${INPUT_SUMMARIZE}
+  fi
+
   if [ -z "${INPUT_OWNER}" ]
   then
     echo "Error: Owner is a required argument."
@@ -178,6 +184,15 @@ wait_for_workflow_to_finish() {
 
   if [ -n "${INPUT_COMMENT_DOWNSTREAM_URL}" ]; then
     comment_downstream_link ${last_workflow_url}
+  fi
+
+  if [ "${summarize}" = true ]
+  then
+    echo "| | |" >> $GITHUB_STEP_SUMMARY
+    echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+    echo "| Workflow URL | <${last_workflow_url}> |" >> $GITHUB_STEP_SUMMARY
+    echo "| Workflow ID | ${last_workflow_id} |" >> $GITHUB_STEP_SUMMARY
+    echo "| | |" >> $GITHUB_STEP_SUMMARY
   fi
 
   conclusion=null


### PR DESCRIPTION
Add an option to print the downstream workflow URL to the job summary, which is easier than looking for it in the log file.

I was hoping the summary would print while the downstream job is running, but it seems to only print after it's done...