### PR TITLE
feat: repeat workflow URL to make it easier to find

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -193,6 +193,7 @@ wait_for_workflow_to_finish() {
 
     echo "Checking conclusion [${conclusion}]"
     echo "Checking status [${status}]"
+    echo "Workflow logs: ${last_workflow_url}"
     echo "conclusion=${conclusion}" >> $GITHUB_OUTPUT
   done
 


### PR DESCRIPTION
The dispatched workflow run URL is already printed once at the beginning of the log file, but if a user views the log file too late and the dispatched workflow is still running, they may miss that printout; they cannot scroll up, since it seems that nowadays GitHub Action log streaming goes as `tail -F` (at least in my experience with Firefox). 

On the other hand, one must wait for the dispatched workflow to finish before #90 is useful.

This PR proposes repeating the dispatched workflow URL at every status check, so the user is guaranteed to see it whenever they view the logs while the dispatched job is still running.