### PR TITLE
fix: add check for empty workflow runs return on initial run

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#580A40",
-    "titleBar.activeBackground": "#7B0F59",
-    "titleBar.activeForeground": "#FFFCFE"
-  }
-}


### PR DESCRIPTION
Update get old workflow runs to return an empty string when there are no previous workflow runs. This solves running a new workflow in another repo which fails with 404 on get old workflow runs in current master branch. 

Changed: 
get_workflow_runs() {
  since=${1:?}

  query="event=workflow_dispatch&created=>=$since${INPUT_GITHUB_USER+&actor=}${INPUT_GITHUB_USER}&per_page=100"

  echo "Getting workflow runs using query: ${query}" >&2

  api "workflows/${INPUT_WORKFLOW_FILE_NAME}/runs?${query}" |
  jq -r '.workflow_runs[].id' |
  sort # Sort to ensure repeatable order, and lexicographically for compatibility with join
}

to: 
get_workflow_runs() {
  since=${1:?}

  query="event=workflow_dispatch&created=>=$since${INPUT_GITHUB_USER+&actor=}${INPUT_GITHUB_USER}&per_page=100"

  echo "Getting workflow runs using query: ${query}" >&2

  runs=$(api "workflows/${INPUT_WORKFLOW_FILE_NAME}/runs?${query}")

  # Check if the output is empty or contains an error message
  if [ -z "$runs" ] || [[ $runs == *"message"* ]]; then
    echo "" # Return an empty string or a default value
  else
    echo "$runs" | jq -r '.workflow_runs[].id' | sort
  fi
}

